### PR TITLE
Remove .development flag file

### DIFF
--- a/.development
+++ b/.development
@@ -1,1 +1,0 @@
-this file lets you edit example files


### PR DESCRIPTION
[The `.development` flag file](https://arduino.github.io/arduino-cli/latest/library-specification/#development-flag-file) disables the Arduino IDE's typical behavior of treating library examples as read-only. This can be useful while developing examples.

The Arduino Library Manager indexer also rejects any release that contains a `.development` flag file. For this reason, the file should not be committed to the repository, except perhaps under specific circumstances where the release is intended to be excluded from Library Manager. There is no indication that is the reason for the `.development` file's presence in this repository so I'm assuming it was added inadvertently.